### PR TITLE
[INT-510] n8n: Address additional problems from n8n code review

### DIFF
--- a/packages/nodes-base/nodes/Onfleet/Onfleet.node.ts
+++ b/packages/nodes-base/nodes/Onfleet/Onfleet.node.ts
@@ -180,7 +180,7 @@ export class Onfleet implements INodeType {
 	};
 
 	/**
-	 * Returns a valid formated destination object
+	 * Returns a valid formatted destination object
 	 * @param unparsed Whether the address is parsed or not
 	 * @param address Destination address
 	 * @param addressNumber Destination number
@@ -234,27 +234,34 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Gets the properties of a destination according to the operation chose
-	 * @param this Current node execution function
 	 * @param item Current execution data
-	 * @param operation Current destination opration
+	 * @param operation Current destination operation
+	 * @param shared Whether the collection is in other resource or not
 	 * @returns {OnfleetDestination} Destination information
 	 */
 	static getDestinationFields(
-		this: IExecuteFunctions, item: number, operation: string, shared = false,
+		this: IExecuteFunctions, item: number, operation: string, shared: { parent: string } | boolean = false,
 	): OnfleetDestination | OnfleetDestination[] | null {
-		if (['create', 'createBatch', 'update'].includes(operation)) {
+		if (['create', 'update'].includes(operation)) {
 			/* -------------------------------------------------------------------------- */
-			/*             Get fields for create, createBatch and update task             */
+			/*               Get fields for create and update a destination               */
 			/* -------------------------------------------------------------------------- */
-			if (shared) {
-				const { destinationProperties: destination } = this.getNodeParameter('destination', item) as IDataObject;
+			if (shared !== false) {
+				let destination;
+				if (typeof shared === 'boolean' && shared) {
+					const { destinationProperties = {} } = this.getNodeParameter('destination', item) as IDataObject;
+					destination = destinationProperties;
+				} else {
+					const { destination: destinationCollection = {} } = this.getNodeParameter(shared.parent, item) as IDataObject;
+					destination = (destinationCollection as IDataObject).destinationProperties;
+				}
 
 				if (!destination || Object.keys((destination) as IDataObject).length === 0) {
 					return [];
 				}
 
 				const {
-					unparsed, address, addressNumber, addressStreet, addressCity, addressCountry, additionalFields,
+					unparsed, address, addressNumber, addressStreet, addressCity, addressCountry, ...additionalFields
 				} = destination as IDataObject;
 				return Onfleet.formatAddress(
 					unparsed as boolean,
@@ -288,10 +295,9 @@ export class Onfleet implements INodeType {
 	}
 
 	/**
-	 * Gets the properties of a administrator according to the operation chose
-	 * @param this Current node execution function
+	 * Gets the properties of an administrator according to the operation chose
 	 * @param item Current execution data
-	 * @param operation Current administrator opration
+	 * @param operation Current administrator operation
 	 * @returns {OnfleetAdmins} Administrator information
 	 */
 	static getAdminFields(this: IExecuteFunctions, item: number, operation: string): OnfleetAdmins | null {
@@ -323,10 +329,9 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Gets the properties of a hub according to the operation chose
-	 * @param this Current node execution function
 	 * @param item Current execution data
-	 * @param operation Current hub opration
-	 * @returns {OnfleetHub} Hub information
+	 * @param operation Current hub operation
+	 * @returns {OnfleetHubs|null} Hub information
 	 */
 	 static getHubFields(this: IExecuteFunctions, item: number, operation: string): OnfleetHubs | null {
 		if (operation === 'create') {
@@ -348,7 +353,7 @@ export class Onfleet implements INodeType {
 			/* -------------------------------------------------------------------------- */
 			/*                          Get fields for update hub                         */
 			/* -------------------------------------------------------------------------- */
-			const destination = Onfleet.getDestinationFields.call(this, item, operation, true) as OnfleetDestination;
+			const destination = Onfleet.getDestinationFields.call(this, item, operation, { parent: 'updateFields' }) as OnfleetDestination;
 			const hubData: OnfleetHubs = { ...destination };
 
 			// Adding additional fields
@@ -361,12 +366,11 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Gets the properties of a worker according to the operation chose
-	 * @param this Current node execution function
 	 * @param item Current execution data
-	 * @param operation Current worker opration
-	 * @returns {OnfleetWorker|OnfleetWorkerFilter|OnfleetWorkerSchedule} Worker information
+	 * @param operation Current worker operation
+	 * @returns {OnfleetWorker|OnfleetWorkerFilter|OnfleetWorkerSchedule|null} Worker information
 	 */
-	 static getWorkerFields(this: IExecuteFunctions, item: number, operation: string): OnfleetWorker | OnfleetWorkerFilter | OnfleetWorkerSchedule | OnfleetWorkerSchedule | null {
+	 static getWorkerFields(this: IExecuteFunctions, item: number, operation: string): OnfleetWorker | OnfleetWorkerFilter  | OnfleetWorkerSchedule | null {
 		if (operation === 'create') {
 			/* -------------------------------------------------------------------------- */
 			/*                        Get fields for create worker                        */
@@ -374,12 +378,12 @@ export class Onfleet implements INodeType {
 			const name = this.getNodeParameter('name', item) as string;
 			const phone = this.getNodeParameter('phone', item) as string;
 			const teams = this.getNodeParameter('teams', item) as string[];
-			const { vehicleProperties: vehicle } = this.getNodeParameter('vehicle', item) as IDataObject;
+			const { vehicleProperties: vehicle = {} } = this.getNodeParameter('vehicle', item) as IDataObject;
 			const workerData: OnfleetWorker = { name, phone, teams };
 
 			// Adding vehicle fields
 			if (Object.keys((vehicle as IDataObject)).length > 0) {
-				const { type, additionalFields: additionalVehicleFields } = vehicle as IDataObject;
+				const { type, additionalFields: additionalVehicleFields = {} } = vehicle as IDataObject;
 				Object.assign(workerData, { vehicle: { type, ...(additionalVehicleFields as IDataObject) } });
 			}
 
@@ -452,9 +456,8 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Gets the properties of a webhooks according to the operation chose
-	 * @param this Current node execution function
 	 * @param item Current execution data
-	 * @param operation Current webhooks opration
+	 * @param operation Current webhooks operation
 	 * @returns {OnfleetWebhook} Webhooks information
 	 */
 	 static getWebhookFields(this: IExecuteFunctions, item: number, operation: string): OnfleetWebhook | null {
@@ -477,7 +480,7 @@ export class Onfleet implements INodeType {
 	}
 
 	/**
-	 * Returns a valid formated recipient object
+	 * Returns a valid formatted recipient object
 	 * @param name Recipient name
 	 * @param phone Recipient phone
 	 * @param additionalFields Recipient additional fields
@@ -504,44 +507,30 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Gets the properties of a recipient according to the operation chose
-	 * @param this Current node execution function
 	 * @param item Current execution data
-	 * @param operation Current recipient opration
+	 * @param operation Current recipient operation
+	 * @param shared Whether the collection is in other resource or not
 	 * @returns {OnfleetRecipient} Recipient information
 	 */
 	static getRecipientFields(
-		this: IExecuteFunctions, item: number, operation: string, shared = false, multiple = false,
+		this: IExecuteFunctions, item: number, operation: string, shared = false,
 	): OnfleetRecipient | OnfleetRecipient[] | null {
-		if (['create', 'createBatch'].includes(operation)) {
+		if (operation === 'create') {
 			/* -------------------------------------------------------------------------- */
 			/*                       Get fields to create recipient                       */
 			/* -------------------------------------------------------------------------- */
 			if (shared) {
-				if (multiple) {
-					const { recipientProperties: recipients } = this.getNodeParameter('recipient', item) as IDataObject;
-					if (!recipients || Object.keys(recipients).length === 0) {
-						return [];
-					}
-					return (recipients as IDataObject[]).map(recipient => {
-						const { recipientName: name, recipientPhone: phone, additionalFields } = recipient as IDataObject;
-						return Onfleet.formatRecipient(
-							name as string,
-							phone as string,
-							additionalFields as IDataObject,
-						);
-					});
-				} else {
-					const { recipientProperties: recipient } = this.getNodeParameter('recipient', item) as IDataObject;
-					if (!recipient || Object.keys(recipient).length === 0) {
-						return null;
-					}
-					const { recipientName: name, recipientPhone: phone, additionalFields } = recipient as IDataObject;
-					return Onfleet.formatRecipient(
-						name as string,
-						phone as string,
-						additionalFields as IDataObject,
-					);
+				const { recipient: recipientData = {} } = this.getNodeParameter('additionalFields', item) as IDataObject;
+				const { recipientProperties: recipient = {} } = recipientData as IDataObject;
+				if (!recipient || Object.keys(recipient).length === 0) {
+					return null;
 				}
+				const { recipientName: name, recipientPhone: phone, ...additionalFields } = recipient as IDataObject;
+				return Onfleet.formatRecipient(
+					name as string,
+					phone as string,
+					additionalFields as IDataObject,
+				);
 			} else {
 				const name = this.getNodeParameter('recipientName', item) as string;
 				const phone = this.getNodeParameter('recipientPhone', item) as string;
@@ -573,22 +562,21 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Gets the properties of a task according to the operation chose
-	 * @param this Current node execution function
-	 * @param items Current execution data
+	 * @param item Current execution data
 	 * @param operation Current task operation
 	 * @returns {OnfleetListTaskFilters | OnfleetTask } Task information
 	 */
 	static getTaskFields(this: IExecuteFunctions, item: number, operation: string):
 		OnfleetListTaskFilters | OnfleetTask | OnfleetCloneTask | OnfleetTaskComplete | OnfleetTaskUpdate | null  {
-		if (['create', 'createBatch'].includes(operation)) {
+		if (operation === 'create') {
 			/* -------------------------------------------------------------------------- */
-			/*                 Get fields to create and createBatch tasks                 */
+			/*                         Get fields to create a task                        */
 			/* -------------------------------------------------------------------------- */
 			const additionalFields = this.getNodeParameter('additionalFields', item) as IDataObject;
 			const destination = Onfleet.getDestinationFields.call(this, item, operation, true) as OnfleetDestination;
 
 			// Adding recipients information
-			const recipient = Onfleet.getRecipientFields.call(this, item, operation, true, false) as OnfleetRecipient;
+			const recipient = Onfleet.getRecipientFields.call(this, item, operation, true) as OnfleetRecipient;
 
 			const taskData: OnfleetTask = { destination, recipients: [ recipient ] };
 			const { completeAfter = null, completeBefore = null, ...extraFields } = additionalFields;
@@ -612,27 +600,26 @@ export class Onfleet implements INodeType {
 			/* -------------------------------------------------------------------------- */
 			/*                          Get fields to clone task                          */
 			/* -------------------------------------------------------------------------- */
-			const { overrides, ...optionFields } = this.getNodeParameter('options', item) as IDataObject;
-			const { overrideProperties } = overrides as IDataObject;
+			const additionalFields = this.getNodeParameter('additionalFields', item) as IDataObject;
 
 			const options: OnfleetCloneTaskOptions = {};
-			if (optionFields.includeMetadata)  options.includeMetadata = optionFields.includeMetadata as boolean;
-			if (optionFields.includeBarcodes)  options.includeBarcodes = optionFields.includeBarcodes as boolean;
-			if (optionFields.includeDependencies)  options.includeDependencies = optionFields.includeDependencies as boolean;
+			if (additionalFields.includeMetadata)  options.includeMetadata = additionalFields.includeMetadata as boolean;
+			if (additionalFields.includeBarcodes)  options.includeBarcodes = additionalFields.includeBarcodes as boolean;
+			if (additionalFields.includeDependencies)  options.includeDependencies = additionalFields.includeDependencies as boolean;
 
 			// Adding overrides data
-			if (overrideProperties && Object.keys(overrideProperties).length > 0) {
-				const {
-					notes, pickupTask, serviceTime, completeAfter, completeBefore,
-				} = overrideProperties as IDataObject;
-				const overridesData = {} as OnfleetCloneOverrideTaskOptions;
+			const {
+				notes, pickupTask, serviceTime, completeAfter, completeBefore,
+			} = additionalFields as IDataObject;
+			const overridesData = {} as OnfleetCloneOverrideTaskOptions;
 
-				if (notes)  overridesData.notes = notes as string;
-				if (typeof pickupTask !== 'undefined')  overridesData.pickupTask = pickupTask as boolean;
-				if (serviceTime)  overridesData.serviceTime = serviceTime as number;
-				if (completeAfter)  overridesData.completeAfter = new Date(completeAfter as Date).getTime();
-				if (completeBefore)  overridesData.completeBefore = new Date(completeBefore as Date).getTime();
+			if (notes)  overridesData.notes = notes as string;
+			if (typeof pickupTask !== 'undefined')  overridesData.pickupTask = pickupTask as boolean;
+			if (serviceTime)  overridesData.serviceTime = serviceTime as number;
+			if (completeAfter)  overridesData.completeAfter = new Date(completeAfter as Date).getTime();
+			if (completeBefore)  overridesData.completeBefore = new Date(completeBefore as Date).getTime();
 
+			if (overridesData && Object.keys(overridesData).length > 0) {
 				options.overrides = overridesData;
 			}
 
@@ -641,20 +628,20 @@ export class Onfleet implements INodeType {
 			/* -------------------------------------------------------------------------- */
 			/*                          Get fields to list tasks                          */
 			/* -------------------------------------------------------------------------- */
-			const filterFields = this.getNodeParameter('filterFields', item) as IDataObject;
+			const filters = this.getNodeParameter('filters', item) as IDataObject;
 			const listTaskData: OnfleetListTaskFilters = {
 				from: new Date(this.getNodeParameter('from', 0) as Date).getTime(),
 			};
 
 			// Adding extra fields to search tasks
-			if (filterFields.to) {
-				listTaskData.to = new Date(filterFields.to as Date).getTime();
+			if (filters.to) {
+				listTaskData.to = new Date(filters.to as Date).getTime();
 			}
-			if (filterFields.state) {
-				listTaskData.state = (filterFields.state as number[]).join(',');
+			if (filters.state) {
+				listTaskData.state = (filters.state as number[]).join(',');
 			}
-			if (filterFields.lastId) {
-				listTaskData.lastId = filterFields.lastId as string;
+			if (filters.lastId) {
+				listTaskData.lastId = filters.lastId as string;
 			}
 
 			return listTaskData;
@@ -673,9 +660,8 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Gets the properties of a team according to the operation chose
-	 * @param this Current node execution function
 	 * @param item Current execution data
-	 * @param operation Current team opration
+	 * @param operation Current team operation
 	 * @returns {OnfleetTeams} Team information
 	 */
 	 static getTeamFields(this: IExecuteFunctions, item: number, operation: string): OnfleetTeams | OnfleetWorkerEstimates | OnfleetTeamAutoDispatch | null {
@@ -706,36 +692,33 @@ export class Onfleet implements INodeType {
 			/* -------------------------------------------------------------------------- */
 			/*      Get driver time estimates for tasks that haven't been created yet     */
 			/* -------------------------------------------------------------------------- */
-			const { dropoffProperties } = this.getNodeParameter('dropoff', item) as IDataObject;
-			const { pickUpProperties } = this.getNodeParameter('pickUp', item) as IDataObject;
-			const dropoff = dropoffProperties as IDataObject;
-			const pickup = pickUpProperties as IDataObject;
-			const hasPickUp = pickup && Object.keys(pickup).length > 0;
-			const hasDropoff = dropoff && Object.keys(dropoff).length > 0;
+			const { dropOff = {}, pickUp = {}, ...additionalFields } = this.getNodeParameter('additionalFields', item) as IDataObject;
+			const { dropOffProperties = {} }= dropOff as IDataObject;
+			const { pickUpProperties = {} }= pickUp as IDataObject;
+			const hasPickUp = pickUp && Object.keys(pickUpProperties as IDataObject).length > 0;
+			const hasDropOff = dropOffProperties && Object.keys(dropOffProperties as IDataObject).length > 0;
 
-			if (!hasPickUp && !hasDropoff) {
+			if (!hasPickUp && !hasDropOff) {
 				throw new NodeOperationError(
-					this.getNode(), 'At least 1 of dropoffLocation or pickupLocation must be selected',
+					this.getNode(), 'At least 1 of Drop-Off location or Pick-Up location must be selected',
 				);
 			}
 
 			const workerTimeEstimates = {} as OnfleetWorkerEstimates;
 			if (hasPickUp) {
 				const {
-					pickupLongitude: longitude, pickupLatitude: latitude, additionalFields,
-				} = pickup;
-				const { pickupTime } = additionalFields as IDataObject;
+					pickupLongitude: longitude, pickupLatitude: latitude, pickupTime,
+				} = pickUpProperties as IDataObject;
 				workerTimeEstimates.pickupLocation = `${longitude},${latitude}`;
 				if (pickupTime) {
 					workerTimeEstimates.pickupTime = moment(new Date(pickupTime as Date)).local().unix();
 				}
 			}
-			if(hasDropoff) {
-				const {dropoffLongitude: longitude, dropoffLatitude: latitude} = dropoff;
+			if(hasDropOff) {
+				const { dropOffLongitude: longitude, dropOffLatitude: latitude} = dropOffProperties as IDataObject;
 				workerTimeEstimates.dropoffLocation = `${longitude},${latitude}`;
 			}
 
-			const additionalFields = this.getNodeParameter('additionalFields', item) as IDataObject;
 			Object.assign(workerTimeEstimates, additionalFields);
 			return workerTimeEstimates;
 		} else if (operation === 'autoDispatch') {
@@ -744,16 +727,27 @@ export class Onfleet implements INodeType {
 			/* -------------------------------------------------------------------------- */
 			const teamAutoDispatch = {} as OnfleetTeamAutoDispatch;
 			const {
-				scheduleTimeWindow, taskTimeWindow, ...additionalFields
+				scheduleTimeWindow = {}, taskTimeWindow = {}, endingRoute = {}, ...additionalFields
 			} = this.getNodeParameter('additionalFields', item) as IDataObject;
-			const { scheduleTimeWindowProperties } = scheduleTimeWindow as IDataObject;
-			const { taskTimeWindowProperties } = taskTimeWindow as IDataObject;
+			const { endingRouteProperties = {} } = endingRoute as IDataObject;
+			const { scheduleTimeWindowProperties = {} } = scheduleTimeWindow as IDataObject;
+			const { taskTimeWindowProperties = {} } = taskTimeWindow as IDataObject;
 
 			if (scheduleTimeWindowProperties && Object.keys((scheduleTimeWindowProperties as IDataObject)).length > 0) {
 				const { startTime, endTime } = scheduleTimeWindowProperties as IDataObject;
 				teamAutoDispatch.scheduleTimeWindow = [
 					moment(new Date(startTime as Date)).local().unix(), moment(new Date(endTime as Date)).local().unix(),
 				];
+			}
+
+			if (endingRouteProperties && Object.keys((endingRouteProperties as IDataObject)).length > 0) {
+				const { routeEnd, hub } = endingRouteProperties as IDataObject;
+				teamAutoDispatch.routeEnd = ({
+					'anywhere': null,
+					'hub': `hub://${hub}`,
+					'team_hub': 'teams://DEFAULT',
+					'worker_routing_address': 'workers://ROUTING_ADDRESS',
+				})[routeEnd as string] as string;
 			}
 
 			if (taskTimeWindowProperties && Object.keys((taskTimeWindowProperties as IDataObject)).length > 0) {
@@ -771,7 +765,6 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the task operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Task)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
@@ -785,7 +778,7 @@ export class Onfleet implements INodeType {
 		items: INodeExecutionData[],
 		encodedApiKey: string,
 		): Promise<IDataObject | IDataObject[]> {
-		if (operation === 'createBatch') {
+		if (operation === 'create' && Object.keys(items).length > 1) {
 			/* -------------------------------------------------------------------------- */
 			/*                       Create multiple tasks by batch                       */
 			/* -------------------------------------------------------------------------- */
@@ -811,7 +804,7 @@ export class Onfleet implements INodeType {
 					/*                              Get a single task                             */
 					/* -------------------------------------------------------------------------- */
 					const id = this.getNodeParameter('id', index) as string;
-					const shortId = this.getNodeParameter('shortId', index) as boolean;
+					const shortId = String(id).length <= 8;
 					const path = `${resource}${(shortId ? '/shortId' : '')}/${id}`;
 					responseData.push(await onfleetApiRequest.call(this, 'GET', encodedApiKey, path));
 				} else if (operation === 'clone') {
@@ -829,7 +822,8 @@ export class Onfleet implements INodeType {
 					/* -------------------------------------------------------------------------- */
 					const id = this.getNodeParameter('id', index) as string;
 					const path = `${resource}/${id}`;
-					responseData.push(await onfleetApiRequest.call(this, 'DELETE', encodedApiKey, path));
+					await onfleetApiRequest.call(this, 'DELETE', encodedApiKey, path);
+					return { success: true };
 				} else if (operation === 'getAll') {
 					/* -------------------------------------------------------------------------- */
 					/*                                Get all tasks                               */
@@ -848,7 +842,8 @@ export class Onfleet implements INodeType {
 					const taskData = Onfleet.getTaskFields.call(this, index, operation);
 					if (!taskData) { continue; }
 					const path = `${resource}/${id}/complete`;
-					responseData.push(await onfleetApiRequest.call(this, 'POST', encodedApiKey, path, taskData));
+					await onfleetApiRequest.call(this, 'POST', encodedApiKey, path, taskData);
+					return { success: true };
 				} else if (operation === 'update') {
 					/* -------------------------------------------------------------------------- */
 					/*                                Update a task                               */
@@ -863,7 +858,6 @@ export class Onfleet implements INodeType {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 		return responseData;
@@ -871,7 +865,6 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the destination operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Destination)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
@@ -891,7 +884,7 @@ export class Onfleet implements INodeType {
 			try {
 				if (operation === 'create') {
 					/* -------------------------------------------------------------------------- */
-					/*                             Create destiantion                             */
+					/*                             Create destination                             */
 					/* -------------------------------------------------------------------------- */
 					const destinationData = Onfleet.getDestinationFields.call(this, index, operation);
 					if (!destinationData) { continue; }
@@ -908,7 +901,6 @@ export class Onfleet implements INodeType {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 
@@ -917,7 +909,6 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the organization operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Organization)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
@@ -953,7 +944,6 @@ export class Onfleet implements INodeType {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 
@@ -962,7 +952,6 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the recipient operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Recipient)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
@@ -1008,7 +997,6 @@ export class Onfleet implements INodeType {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 
@@ -1017,7 +1005,6 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the administrator operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Administrator)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
@@ -1060,13 +1047,13 @@ export class Onfleet implements INodeType {
 					/* -------------------------------------------------------------------------- */
 					const id = this.getNodeParameter('id', index) as string;
 					const path = `${resource}/${id}`;
-					responseData.push(await onfleetApiRequest.call(this, 'DELETE', encodedApiKey, path));
+					await onfleetApiRequest.call(this, 'DELETE', encodedApiKey, path);
+					return  { success: true };
 				}
 			} catch (error) {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 
@@ -1075,7 +1062,6 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the hub operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Hub)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
@@ -1118,7 +1104,6 @@ export class Onfleet implements INodeType {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 
@@ -1127,7 +1112,6 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the worker operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Worker)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
@@ -1215,7 +1199,6 @@ export class Onfleet implements INodeType {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 
@@ -1224,7 +1207,6 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the webhook operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Webhook)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
@@ -1265,7 +1247,6 @@ export class Onfleet implements INodeType {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 
@@ -1274,12 +1255,11 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the containers operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Container)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
 	 * @param encodedApiKey API KEY for the current organization
-	 * @returns Contianer information
+	 * @returns Container information
 	 */
 	 static async executeContainerOperations(
 		this: IExecuteFunctions,
@@ -1328,7 +1308,6 @@ export class Onfleet implements INodeType {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 
@@ -1337,7 +1316,6 @@ export class Onfleet implements INodeType {
 
 	/**
 	 * Execute the team operations
-	 * @param this Execute function
 	 * @param resource Resource to be executed (Team)
 	 * @param operation Operation to be executed
 	 * @param items Number of items to process by the node
@@ -1387,7 +1365,8 @@ export class Onfleet implements INodeType {
 					/* -------------------------------------------------------------------------- */
 					const id = this.getNodeParameter('id', index) as string;
 					const path = `${resource}/${id}`;
-					responseData.push(await onfleetApiRequest.call(this, 'DELETE', encodedApiKey, path));
+					await onfleetApiRequest.call(this, 'DELETE', encodedApiKey, path);
+					return { success: true };
 				} else if (operation === 'getTimeEstimates') {
 					/* -------------------------------------------------------------------------- */
 					/*      Get driver time estimates for tasks that haven't been created yet     */
@@ -1409,7 +1388,6 @@ export class Onfleet implements INodeType {
 				if (this.continueOnFail()) {
 					responseData.push({ error: (error as IDataObject).toString() });
 				}
-				continue;
 			}
 		}
 

--- a/packages/nodes-base/nodes/Onfleet/Onfleet.node.ts
+++ b/packages/nodes-base/nodes/Onfleet/Onfleet.node.ts
@@ -660,9 +660,11 @@ export class Onfleet implements INodeType {
 			/*                          Get fields to list tasks                          */
 			/* -------------------------------------------------------------------------- */
 			const filters = this.getNodeParameter('filters', item) as IDataObject;
-			const listTaskData: OnfleetListTaskFilters = {
-				from: new Date(this.getNodeParameter('from', 0) as Date).getTime(),
-			};
+			const from = this.getNodeParameter('from', 0);
+			if (!from) {
+				throw new NodeOperationError(this.getNode(), 'From is required');
+			}
+			const listTaskData: OnfleetListTaskFilters = { from: new Date(from as Date).getTime() };
 
 			// Adding extra fields to search tasks
 			if (filters.to) {

--- a/packages/nodes-base/nodes/Onfleet/OnfleetTrigger.node.ts
+++ b/packages/nodes-base/nodes/Onfleet/OnfleetTrigger.node.ts
@@ -8,14 +8,17 @@ import {
 	IWebhookResponseData,
 	NodeApiError,
 	NodeCredentialTestResult,
-	NodeOperationError,
+	NodeOperationError
 } from 'n8n-workflow';
 import {
 	IHookFunctions,
 	IWebhookFunctions,
 } from 'n8n-core';
 
-import { eventDisplay, eventNameField } from './descriptions/OnfleetWebhookDescription';
+import {
+	eventDisplay,
+	eventNameField,
+} from './descriptions/OnfleetWebhookDescription';
 import { onfleetApiRequest } from './GenericFunctions';
 import { webhookMapping } from './WebhookMapping';
 import { OptionsWithUri } from 'request';
@@ -143,7 +146,7 @@ export class OnfleetTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 
@@ -153,7 +156,6 @@ export class OnfleetTrigger implements INodeType {
 				const credentials = await this.getCredentials('onfleetApi') as ICredentialDataDecryptedObject;
 				const encodedApiKey = Buffer.from(`${credentials.apiKey}:`).toString('base64');
 				const event = this.getNodeParameter('event', 0) as string;
-				const webhookData = this.getWorkflowStaticData('node');
 				const webhookUrl = this.getNodeWebhookUrl('default') as string;
 
 				if (webhookUrl.includes('//localhost')) {
@@ -210,8 +212,7 @@ export class OnfleetTrigger implements INodeType {
 	};
 
 	/**
-	 * Triggered function when a Onfleet webhook is executed
-	 * @param this Webhook functions
+	 * Triggered function when an Onfleet webhook is executed
 	 * @returns {Promise<IWebhookResponseData>} Response data
 	 */
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
@@ -225,8 +226,7 @@ export class OnfleetTrigger implements INodeType {
 			return { noWebhookResponse: true };
 		}
 
-		const bodyData = this.getBodyData();
-		const returnData: IDataObject = bodyData;
+		const returnData: IDataObject = this.getBodyData();
 
 		return {
 			workflowData: [

--- a/packages/nodes-base/nodes/Onfleet/descriptions/ContainerDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/ContainerDescription.ts
@@ -94,7 +94,7 @@ const indexField = {
 } as INodeProperties;
 
 const tasksField = {
-	displayName: 'Tasks',
+	displayName: 'Task IDs',
 	name: 'tasks',
 	type: 'string',
 	typeOptions: {

--- a/packages/nodes-base/nodes/Onfleet/descriptions/DestinationDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/DestinationDescription.ts
@@ -170,39 +170,25 @@ export const destinationExternalField = {
 					required: true,
 				},
 				{
-					displayName: 'Additional Fields',
-					name: 'additionalFields',
-					type: 'collection',
-					placeholder: 'Add Field',
-					default: {},
-					displayOptions: {
-						show: {
-							unparsed: [ true ],
-						},
-					},
-					options: [
-						addressNameField,
-						addressApartmentField,
-						addressNoteField,
-					],
+					...addressNameField,
+					required: false,
 				},
 				{
-					displayName: 'Additional Fields',
-					name: 'additionalFields',
-					type: 'collection',
-					placeholder: 'Add Field',
-					default: {},
+					...addressApartmentField,
+					required: false,
+				},
+				{
+					...addressNoteField,
+					required: false,
+				},
+				{
 					displayOptions: {
 						show: {
 							unparsed: [ false ],
 						},
 					},
-					options: [
-						addressNameField,
-						addressApartmentField,
-						addressNoteField,
-						addressPostalCodeField,
-					],
+					...addressPostalCodeField,
+					required: false,
 				},
 			],
 		},

--- a/packages/nodes-base/nodes/Onfleet/descriptions/HubDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/HubDescription.ts
@@ -83,10 +83,7 @@ export const hubFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: [ 'hub' ],
-				operation: [
-					'create',
-					'update',
-				],
+				operation: [ 'create' ],
 			},
 		},
 	},
@@ -125,6 +122,10 @@ export const hubFields: INodeProperties[] = [
 			nameField,
 			{
 				...teamsField,
+				required: false,
+			},
+			{
+				...destinationExternalField,
 				required: false,
 			},
 		],

--- a/packages/nodes-base/nodes/Onfleet/descriptions/RecipientDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/RecipientDescription.ts
@@ -40,6 +40,7 @@ const additionalRecipientFields: INodeProperties[] = [
 		type: 'string',
 		default: '',
 		description: 'Notes for this recipient: these are global notes that should not be task- or destination-specific',
+		required: false,
 	},
 	{
 		displayName: 'Skip Recipient SMS Notifications',
@@ -47,6 +48,7 @@ const additionalRecipientFields: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		description: 'Whether this recipient has requested to skip SMS notifications',
+		required: false,
 	},
 	{
 		displayName: 'Skip Recipient Phone Number Validation',
@@ -54,6 +56,7 @@ const additionalRecipientFields: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		description: 'Whether to skip validation for this recipient\'s phone number',
+		required: false,
 	},
 ];
 
@@ -124,14 +127,7 @@ export const recipientExternalField = {
 					...recipientPhone,
 					required: true,
 				},
-				{
-					displayName: 'Additional Fields',
-					name: 'additionalFields',
-					type: 'collection',
-					placeholder: 'Add Field',
-					default: {},
-					options: additionalRecipientFields,
-				},
+				...additionalRecipientFields,
 			],
 		},
 	],

--- a/packages/nodes-base/nodes/Onfleet/descriptions/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/TaskDescription.ts
@@ -221,7 +221,7 @@ export const taskFields: INodeProperties[] = [
 						value: 0,
 					},
 				],
-				default: '',
+				default: [],
 				description: 'The state of the tasks',
 			},
 			{

--- a/packages/nodes-base/nodes/Onfleet/descriptions/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/TaskDescription.ts
@@ -21,11 +21,6 @@ export const taskOperations: INodeProperties[] = [
 				description: 'Create a new Onfleet task',
 			},
 			{
-				name: 'Create Multiple Tasks',
-				value: 'createBatch',
-				description: 'Creating multiple tasks in batch',
-			},
-			{
 				name: 'Clone',
 				value: 'clone',
 				description: 'Clone an Onfleet task',
@@ -137,7 +132,6 @@ export const taskFields: INodeProperties[] = [
 			hide: {
 				operation: [
 					'create',
-					'createBatch',
 					'getAll',
 				],
 			},
@@ -151,40 +145,11 @@ export const taskFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: [ 'task' ],
-				operation: [
-					'create',
-					'createBatch',
-				],
+				operation: [ 'create' ],
 			},
 		},
 		default: {},
-	},
-	{
-		...recipientExternalField,
-		displayOptions: {
-			show: {
-				resource: [ 'task' ],
-				operation: [
-					'create',
-					'createBatch',
-				],
-			},
-		},
-		default: {},
-	},
-	{
-		displayName: 'Short ID',
-		name: 'shortId',
-		type: 'boolean',
-		displayOptions: {
-			show: {
-				resource: [ 'task' ],
-				operation: [ 'get' ],
-			},
-		},
 		required: true,
-		description: 'Whether the task short ID is used for lookup',
-		default: false,
 	},
 	{
 		displayName: 'From',
@@ -198,7 +163,7 @@ export const taskFields: INodeProperties[] = [
 		},
 		description: 'The starting time of the range. Tasks created or completed at or after this time will be included.',
 		required: true,
-		default: null,
+		default: '',
 	},
 	{
 		displayName: 'Success',
@@ -215,10 +180,10 @@ export const taskFields: INodeProperties[] = [
 		default: true,
 	},
 	{
-		displayName: 'Filter Fields',
-		name: 'filterFields',
+		displayName: 'Filters',
+		name: 'filters',
 		type: 'collection',
-		placeholder: 'Add Field',
+		placeholder: 'Add Filter',
 		default: {},
 		displayOptions: {
 			show: {
@@ -269,10 +234,10 @@ export const taskFields: INodeProperties[] = [
 		],
 	},
 	{
-		displayName: 'Options',
-		name: 'options',
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
 		type: 'collection',
-		placeholder: 'Add options',
+		placeholder: 'Add Field',
 		default: {},
 		displayOptions: {
 			show: {
@@ -300,39 +265,24 @@ export const taskFields: INodeProperties[] = [
 				default: false,
 			},
 			{
-				displayName: 'Overrides',
-				name: 'overrides',
-				type: 'fixedCollection',
-				default: {},
-				options: [
-					{
-						displayName: 'Override Properties',
-						name: 'overrideProperties',
-						default: {},
-						values: [
-							{
-								...notesField,
-								required: false,
-							},
-							{
-								...pickupTaskField,
-								required: false,
-							},
-							{
-								...serviceTimeField,
-								required: false,
-							},
-							{
-								...completeAfterField,
-								required: false,
-							},
-							{
-								...completeBeforeField,
-								required: false,
-							},
-						],
-					},
-				],
+				...notesField,
+				required: false,
+			},
+			{
+				...pickupTaskField,
+				required: false,
+			},
+			{
+				...serviceTimeField,
+				required: false,
+			},
+			{
+				...completeAfterField,
+				required: false,
+			},
+			{
+				...completeBeforeField,
+				required: false,
 			},
 		],
 	},
@@ -382,7 +332,7 @@ export const taskFields: INodeProperties[] = [
 		],
 	},
 	{
-		displayName: 'Additional Task Fields',
+		displayName: 'Additional Fields',
 		name: 'additionalFields',
 		type: 'collection',
 		placeholder: 'Add Field',
@@ -390,13 +340,11 @@ export const taskFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: [ 'task' ],
-				operation: [
-					'create',
-					'createBatch',
-				],
+				operation: [ 'create' ],
 			},
 		},
 		options: [
+			recipientExternalField,
 			merchantIdField,
 			executorIdField,
 			completeAfterField,

--- a/packages/nodes-base/nodes/Onfleet/descriptions/TeamDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/TeamDescription.ts
@@ -128,7 +128,13 @@ const serviceTimeField = {
 const routeEndField = {
 	displayName: 'Route End',
 	name: 'routeEnd',
-	type: 'string',
+	type: 'options',
+	options: [
+		{ name: 'Team’s Hub', value: 'team_hub' },
+		{ name: 'Worker Routing Address', value: 'worker_routing_address' },
+		{ name: 'Hub', value: 'hub' },
+		{ name: 'End Anywhere', value: 'anywhere' },
+	],
 	default: '',
 	description: 'Where the route will end',
 } as INodeProperties;
@@ -144,26 +150,26 @@ const maxAllowedDelayField = {
 	},
 } as INodeProperties;
 
-const longitudeDropoffField = {
-	displayName: 'Dropoff Longitude',
-	name: 'dropoffLongitude',
+const longitudeDropOffField = {
+	displayName: 'Drop Off Longitude',
+	name: 'dropOffLongitude',
 	type: 'number',
 	typeOptions: {
 		numberPrecision: 14,
 	},
 	default: 0,
-	description: 'The longitude for dropoff location',
+	description: 'The longitude for drop off location',
 } as INodeProperties;
 
-const latitudeDropoffField = {
-	displayName: 'Dropoff Latitude',
-	name: 'dropoffLatitude',
+const latitudeDropOffField = {
+	displayName: 'Drop Off Latitude',
+	name: 'dropOffLatitude',
 	type: 'number',
 	typeOptions: {
 		numberPrecision: 14,
 	},
 	default: 0,
-	description: 'The latitude for dropoff location',
+	description: 'The latitude for drop off location',
 } as INodeProperties;
 
 const longitudePickupField = {
@@ -336,7 +342,35 @@ export const teamFields: INodeProperties[] = [
 		options: [
 			maxAllowedDelayField,
 			maxTasksPerRouteField,
-			routeEndField,
+			{
+				displayName: 'Ending Route',
+				name: 'endingRoute',
+				type: 'fixedCollection',
+				default: {},
+				options: [
+					{
+						displayName: 'Ending Route Properties',
+						name: 'endingRouteProperties',
+						type: 'fixedCollection',
+						default: {},
+						values: [
+							{
+								...routeEndField,
+								required: true,
+							},
+							{
+								...hubField,
+								displayOptions: {
+									show: {
+										routeEnd: [ 'hub' ],
+									},
+								},
+								required: false,
+							},
+						],
+					},
+				],
+			},
 			{
 				displayName: 'Schedule Time Window',
 				name: 'scheduleTimeWindow',
@@ -397,64 +431,62 @@ export const teamFields: INodeProperties[] = [
 		],
 	},
 	{
-		displayName: 'Dropoff',
-		name: 'dropoff',
-		type: 'fixedCollection',
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Fields',
+		default: {},
 		displayOptions: {
 			show: {
 				resource: [ 'team' ],
 				operation: [ 'getTimeEstimates' ],
 			},
 		},
-		default: {},
 		options: [
 			{
-				displayName: 'Dropoff Properties',
-				name: 'dropoffProperties',
-				values: [
+				displayName: 'Drop Off',
+				name: 'dropOff',
+				type: 'fixedCollection',
+				default: {},
+				options: [
 					{
-						...longitudeDropoffField,
-						required: true,
-					},
-					{
-						...latitudeDropoffField,
-						required: true,
+						displayName: 'DropOff Properties',
+						name: 'dropOffProperties',
+						type: 'fixedCollection',
+						default: {},
+						values: [
+							{
+								...longitudeDropOffField,
+								required: true,
+							},
+							{
+								...latitudeDropOffField,
+								required: true,
+							},
+						],
 					},
 				],
 			},
-		],
-	},
-	{
-		displayName: 'Pick Up',
-		name: 'pickUp',
-		type: 'fixedCollection',
-		displayOptions: {
-			show: {
-				resource: [ 'team' ],
-				operation: [ 'getTimeEstimates' ],
-			},
-		},
-		default: {},
-		options: [
 			{
-				displayName: 'Pick Up Properties',
-				name: 'pickUpProperties',
-				values: [
+				displayName: 'Pick Up',
+				name: 'pickUp',
+				type: 'fixedCollection',
+				default: {},
+				options: [
 					{
-						...longitudePickupField,
-						required: true,
-					},
-					{
-						...latitudePickupField,
-						required: true,
-					},
-					{
-						displayName: 'Additional Fields',
-						name: 'additionalFields',
-						type: 'collection',
-						placeholder: 'Add Field',
+						displayName: 'Pick Up Properties',
+						name: 'pickUpProperties',
+						type: 'fixedCollection',
 						default: {},
-						options: [
+						values: [
+							{
+								...longitudePickupField,
+								required: true,
+							},
+							{
+								...latitudePickupField,
+								required: true,
+							},
 							{
 								...pickupTimeField,
 								required: false,
@@ -463,21 +495,6 @@ export const teamFields: INodeProperties[] = [
 					},
 				],
 			},
-		],
-	},
-	{
-		displayName: 'Additional Fields',
-		name: 'additionalFields',
-		type: 'collection',
-		placeholder: 'Add fields',
-		default: {},
-		displayOptions: {
-			show: {
-				resource: [ 'team' ],
-				operation: [ 'getTimeEstimates' ],
-			},
-		},
-		options: [
 			{
 				...restrictedVehicleTypesField,
 				required: false,

--- a/packages/nodes-base/nodes/Onfleet/descriptions/WorkerDescription.ts
+++ b/packages/nodes-base/nodes/Onfleet/descriptions/WorkerDescription.ts
@@ -183,7 +183,7 @@ const statesFilterField = {
 			value: 0,
 		},
 	],
-	default: '',
+	default: [],
 	description: 'List of worker states',
 } as INodeProperties;
 
@@ -285,7 +285,7 @@ const filterField = {
 			value: 'id',
 		},
 	],
-	default: '',
+	default: [],
 	description: 'A list of fields to show in the response, if all are not desired',
 } as INodeProperties;
 


### PR DESCRIPTION
### Onfleet review

### Admin resource

#### Admin:getAll

- [ ] Missing pagination

####  Admin:delete

- [x] Return { success: true } when the operation is successfull

### Task resource

- [x] Do only task:create and do the batching behind the scenes. Batching if available should be the implementation to use.

#### Task:create

- [x] Every field that is not required should be under a collection. I was able to create a task only with the destination address, which means, that recipients it’s not required
- [x] When setting the address you have a collection called “additional fields” that is not necessary. Add them at the same level of the destination address and make them not required. Do the same with Recipient
- [x] Rename additional task fields to Additional Fields

#### Task:clone

- [x] If the operation does not return anything when it ran successfully return { success: true }
- [x] Rename collection options to additional fields
- [x] Move what is inside the collection override to the same level the options parameters are

#### Task:complete

- [ ] If this operation completes the task why would I make the success parameter false?
- [x] Return { success: true } when the operation is successful

#### Task:delete

- [x] Return { success: true } when the operation is successfull

#### Task:getAll

- [ ] Missing pagination
- [ ] From does not seem to be a required parameter. Add It under the collection filter fields
- [x] Rename filter fields collection to filters
- [ ] Remove Last ID parameter.
- [x] It does not seem to return the task I created

#### Task:get

- [x] Is the short id parameter really needed? Can just detect that behind the scenes and make the corresponding call?

### Container resource

- [ ] I would probably only leave the get operation for this resource. Then, move insert and update to another resource called containerTask.

#### Container:insertTasks

- [ ] I would create different operations depending on the insert type. for example: containerTask:append, containerTask:Prepend.
- [ ] Rename tasks to Task IDs

### Hub resource

#### Hub:getAll

- [ ] Missing pagination

#### Hub:update

- [x] Destination should be under update fields

### Team resource

#### Team:auto-dispatch

- [x] What is road end exactly? an address?
- [x] Return { success: true } when the operation is successfull

#### Team:create

- [ ] All the fields marked as required, are not actually required. Everything that is not required should not be at the main level but instead should be moved underneath a collection. In this case, the additional fields collection

#### Team:delete

- [x] Return { success: true } when the operation is successfull

#### Team:getAll

- [ ] Missing pagination

#### Team:getTimeStimates

- [x] Dropoff and pickup do not seem to be required parameters. Both need to be under additional fields if this is the case

### Webhook resource

- [ ] Is it the webhook resource usufull in the node? I would not say so, since we are already using those endpoints in the trigger. Do you have a use case in mind where you need to create Webhooks dynamically?

### Worker resource

#### Worker:create

- [x] It does not seem to be working. No matter the input I provide.

#### worker:getAll

- [ ] Missing pagination